### PR TITLE
Fix font stack: move Microsoft JhengHei to fallback and correct Segoe…

### DIFF
--- a/source/css/font.styl
+++ b/source/css/font.styl
@@ -8,4 +8,4 @@
   font-weight 300
   font-display swap
 
-$font-family = 'Microsoft Jhenghei',Lantinghei SC, 'lanting', PingFang SC, Seguo UI, Microsoft Yahei, Arial
+$font-family = 'lanting', Lantinghei SC, PingFang SC, 'Microsoft Jhenghei', Segoe UI, Microsoft Yahei, Arial


### PR DESCRIPTION
… UI spelling

Microsoft JhengHei is moved later in the font-family list because it uses Traditional Chinese glyphs. Also fix the misspelling of "Segoe UI".

微软正黑体面向繁体设计，不适配简体字形。且项目默认嵌入的字体实为兰亭。同时改正一处错误拼写。